### PR TITLE
Fix default settings and upload endpoint

### DIFF
--- a/app/api/v1/routes.py
+++ b/app/api/v1/routes.py
@@ -8,7 +8,11 @@ from app.services.auth.email_password.schemas import (EmailRegistrationInput, Em
 
 router = APIRouter()
 
-@router.post("/upload", response_model=ImageUploadResponse)
+# The upload endpoint previously omitted a trailing slash.  FastAPI interprets
+# this strictly and would issue a ``307 Temporary Redirect`` when clients send a
+# path ending with ``/`` (as the tests do).  Declaring the route with the
+# trailing slash avoids the redirect and returns the intended status codes.
+@router.post("/upload/", response_model=ImageUploadResponse)
 async def upload_image(file: UploadFile = File(...), metadata: str = Form(...)):
     try:
         meta_obj = ImageUploadInputRequest.model_validate_json(metadata)

--- a/app/configs/settings.py
+++ b/app/configs/settings.py
@@ -9,30 +9,50 @@ class Settings(BaseSettings):
         env_file = Path(__file__).resolve().parent.parent.parent /'.env',
         env_file_encoding = 'utf-8'
     )
-    env: Literal["dev", "staging", "production"] = "development"
+    """Application environment.
+
+    The previous default value was ``"development"`` which was not one of the
+    allowed literals (``"dev"``, ``"staging"`` or ``"production"``).  This caused
+    ``pydantic`` to raise a validation error during settings initialisation and
+    prevented the application and tests from starting.  Using ``"dev"`` keeps the
+    intention of a development environment while matching the permitted values.
+    """
+    env: Literal["dev", "staging", "production"] = "dev"
     debug: bool = True
 
     azure_vision_key: str = 'azure_vision_key'
     azure_vision_endpoint: str = 'azure_vision_endpoint'
 
+    # Database connection defaults.  The previous placeholders prevented
+    # SQLAlchemy from even parsing the connection URL (for instance the port was
+    # non-numeric and the password contained angle brackets).  Using sensible
+    # dummy values keeps the configuration optional while allowing the engine to
+    # be initialised during tests.
     postgres_user: str = 'pg_user'
-    postgres_password: str = '<PASSWORD>'
+    postgres_password: str = 'pg_password'
     postgres_host: str = 'pg_host'
-    postgres_port: str = 'pg_port'
+    postgres_port: int = 5432
     postgres_dbname: str = 'pg_dbname'
     postgres_timeout: int = 5
 
+    # DigitalOcean Spaces (S3 compatible) configuration.  Provide benign defaults
+    # so that the storage client can be constructed in tests without contacting
+    # the network or failing validation.
     do_spaces_key: str = 'do_space_key'
     do_spaces_secret: str = 'do_space_secret'
-    do_spaces_region: str = 'do_space_region'
+    do_spaces_region: str = 'us-east-1'
     do_spaces_bucket: str = 'do_space_bucket'
-    do_spaces_endpoint: str = 'do_space_endpoint'
+    do_spaces_endpoint: str = 'https://example.com'
 
     # email related
     mail_verify_base_url: str = 'mail-verify-base-url'
     mail_username: str = "mail_username"
     mail_password: SecretStr = "mail_password"
-    mail_from: EmailStr = "mail_from"
+    # ``EmailStr`` requires a valid e‑mail address.  The previous placeholder
+    # lacked an ``@`` and failed validation which also stopped the application
+    # from starting.  A syntactically valid example address avoids that issue
+    # while remaining obviously a placeholder.
+    mail_from: EmailStr = "noreply@example.com"
     mail_server: str = "mail_server"
     mail_port: int = 587
     mail_starttls: bool = True


### PR DESCRIPTION
## Summary
- ensure Settings uses valid defaults for environment, database and storage credentials
- adjust upload endpoint to include trailing slash to avoid 307 redirects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0543c1a0832686e2dbbac8c71a38