### PR TITLE
Add endpoint to fetch user uploaded images

### DIFF
--- a/app/api/v1/routes.py
+++ b/app/api/v1/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, File, UploadFile, Form, HTTPException, Query, Depends, Request
 
 from app.db.pg_engine import get_db_session
-from app.services.image_uploads.schemas import ImageUploadResponse, ImageUploadInputRequest
+from app.services.image_uploads.schemas import ImageUploadResponse, ImageUploadInputRequest, UserImage
 from app.services.image_uploads.uploads import upload_service
 from app.services.auth.email_password.email_registration import email_registration
 from app.services.auth.email_password.login_user_pass import LoginUserPass
@@ -30,11 +30,18 @@ async def upload_image(file: UploadFile = File(...), metadata: str = Form(...)):
     upload_resp = await upload_service.upload_image(
         file,
         user_id=meta_obj.user_id,
+        script_id=meta_obj.script_id,
         chapter=meta_obj.chapter,
         ayat_start=meta_obj.ayat_start,
-        ayat_end=meta_obj.ayat_end
+        ayat_end=meta_obj.ayat_end,
     )
     return upload_resp
+
+
+@router.get("/images/{script_id}/", response_model=list[UserImage])
+async def get_script_images(script_id: int):
+    images = await upload_service.get_script_images(script_id)
+    return images
 
 @router.post("/register", response_model=EmailRegistrationResponse, status_code=201)
 async def register(user_in: EmailRegistrationInput):

--- a/app/api/v1/routes.py
+++ b/app/api/v1/routes.py
@@ -38,9 +38,9 @@ async def upload_image(file: UploadFile = File(...), metadata: str = Form(...)):
     return upload_resp
 
 
-@router.get("/images/{script_id}/", response_model=list[UserImage])
-async def get_script_images(script_id: int):
-    images = await upload_service.get_script_images(script_id)
+@router.get("/images/{user_id}/", response_model=list[UserImage])
+async def get_user_images(user_id: int):
+    images = await upload_service.get_user_images(user_id)
     return images
 
 @router.post("/register", response_model=EmailRegistrationResponse, status_code=201)

--- a/app/db/crud/image_uploads.py
+++ b/app/db/crud/image_uploads.py
@@ -1,0 +1,18 @@
+from typing import Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.image_uploads import ImageUploads
+from app.db.pg_dml import get_many
+
+
+class ImageUploadCrud:
+    """CRUD helper for ``ImageUploads`` records."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_script(self, script_id: int) -> Sequence[ImageUploads]:
+        """Return all uploads associated with a ``script_id``."""
+        return await get_many(self.session, ImageUploads, filters={"script_id": script_id})
+

--- a/app/db/crud/image_uploads.py
+++ b/app/db/crud/image_uploads.py
@@ -12,7 +12,7 @@ class ImageUploadCrud:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def get_by_script(self, script_id: int) -> Sequence[ImageUploads]:
-        """Return all uploads associated with a ``script_id``."""
-        return await get_many(self.session, ImageUploads, filters={"script_id": script_id})
+    async def get_by_user(self, user_id: int) -> Sequence[ImageUploads]:
+        """Return all uploads associated with a ``user_id``."""
+        return await get_many(self.session, ImageUploads, filters={"user_id": user_id})
 

--- a/app/db/models/image_uploads.py
+++ b/app/db/models/image_uploads.py
@@ -9,6 +9,7 @@ class ImageUploads(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[int] = mapped_column(BigInteger)
+    script_id: Mapped[int] = mapped_column(BigInteger)
     file_path: Mapped[str] = mapped_column(String(255))
     upload_timestamp: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True))
     chapter: Mapped[int] = mapped_column(SmallInteger)

--- a/app/services/image_uploads/schemas.py
+++ b/app/services/image_uploads/schemas.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 class ImageUploadInputRequest(BaseModel):
     user_id: int
+    script_id: int
     chapter: int
     ayat_start: int
     ayat_end: int
@@ -10,3 +11,11 @@ class ImageUploadInputRequest(BaseModel):
 class ImageUploadResponse(BaseModel):
     file_path: str
     message: str
+
+
+class UserImage(BaseModel):
+    file_path: str
+    script_id: int
+    chapter: int
+    ayat_start: int
+    ayat_end: int

--- a/app/services/image_uploads/uploads.py
+++ b/app/services/image_uploads/uploads.py
@@ -3,9 +3,10 @@ from pathlib import Path
 from datetime import datetime, timezone
 from fastapi import UploadFile, HTTPException
 from app.db.pg_dml import insert_record
+from app.db.crud.image_uploads import ImageUploadCrud
 from app.db.pg_engine import sessionmanager
 from app.db.models.image_uploads import ImageUploads
-from app.services.image_uploads.schemas import ImageUploadResponse
+from app.services.image_uploads.schemas import ImageUploadResponse, UserImage
 from app.configs.constants import ProcessingStatus
 from app.services.storage.do_space import do_space
 
@@ -13,14 +14,22 @@ class UploadService:
     def __init__(self):
         pass
 
-    async def upload_image(self, file: UploadFile, user_id: int,
-                      chapter: int, ayat_start: int, ayat_end: int) -> ImageUploadResponse:
+    async def upload_image(
+        self,
+        file: UploadFile,
+        user_id: int,
+        script_id: int,
+        chapter: int,
+        ayat_start: int,
+        ayat_end: int,
+    ) -> ImageUploadResponse:
         """
         Upload an image and insert record into PostgreSQL database.
         
         Args:
             file (UploadFile): The uploaded image file
             user_id (int): The ID of the user uploading the image
+            script_id (int): Identifier for the related script
             chapter (int): The chapter number
             ayat_start (int): The starting ayat number
             ayat_end (int): The ending ayat number
@@ -43,6 +52,7 @@ class UploadService:
                 upload_record = ImageUploads(
                     file_path=file_url,
                     user_id=user_id,
+                    script_id=script_id,
                     chapter=chapter,
                     ayat_start=ayat_start,
                     ayat_end=ayat_end,
@@ -59,6 +69,24 @@ class UploadService:
                 
             except Exception as e:
                 raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}")
+
+    async def get_script_images(self, script_id: int) -> list[UserImage]:
+        """Fetch uploaded images for a given script."""
+        async with sessionmanager.session() as session:
+            try:
+                records = await ImageUploadCrud(session).get_by_script(script_id)
+                return [
+                    UserImage(
+                        file_path=r.file_path,
+                        script_id=r.script_id,
+                        chapter=r.chapter,
+                        ayat_start=r.ayat_start,
+                        ayat_end=r.ayat_end,
+                    )
+                    for r in records
+                ]
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"Failed to fetch images: {str(e)}")
 
 # Create a singleton instance
 upload_service = UploadService()

--- a/app/services/image_uploads/uploads.py
+++ b/app/services/image_uploads/uploads.py
@@ -70,11 +70,11 @@ class UploadService:
             except Exception as e:
                 raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}")
 
-    async def get_script_images(self, script_id: int) -> list[UserImage]:
-        """Fetch uploaded images for a given script."""
+    async def get_user_images(self, user_id: int) -> list[UserImage]:
+        """Fetch uploaded images for a given user."""
         async with sessionmanager.session() as session:
             try:
-                records = await ImageUploadCrud(session).get_by_script(script_id)
+                records = await ImageUploadCrud(session).get_by_user(user_id)
                 return [
                     UserImage(
                         file_path=r.file_path,

--- a/app/tests/test_fetch_images_endpoints.py
+++ b/app/tests/test_fetch_images_endpoints.py
@@ -6,37 +6,37 @@ from app.services.image_uploads.uploads import upload_service
 
 
 @pytest.mark.asyncio
-async def test_get_script_images_success(monkeypatch, app: FastAPI):
+async def test_get_user_images_success(monkeypatch, app: FastAPI):
     transport = ASGITransport(app=app)
 
     fake_images = [
-        {"file_path": "https://example.com/a.jpg", "script_id": 42, "chapter": 1, "ayat_start": 1, "ayat_end": 2},
-        {"file_path": "https://example.com/b.jpg", "script_id": 42, "chapter": 2, "ayat_start": 3, "ayat_end": 4},
+        {"file_path": "https://example.com/a.jpg", "script_id": 7, "chapter": 1, "ayat_start": 1, "ayat_end": 2},
+        {"file_path": "https://example.com/b.jpg", "script_id": 8, "chapter": 2, "ayat_start": 3, "ayat_end": 4},
     ]
 
-    async def fake_get_script_images(script_id: int):
+    async def fake_get_user_images(user_id: int):
         return fake_images
 
-    monkeypatch.setattr(upload_service, "get_script_images", fake_get_script_images)
+    monkeypatch.setattr(upload_service, "get_user_images", fake_get_user_images)
 
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get("/api/images/42/")
+        resp = await ac.get("/api/images/123/")
 
     assert resp.status_code == 200
     assert resp.json() == fake_images
 
 
 @pytest.mark.asyncio
-async def test_get_script_images_failure(monkeypatch, app: FastAPI):
+async def test_get_user_images_failure(monkeypatch, app: FastAPI):
     transport = ASGITransport(app=app)
 
-    async def broken_get_script_images(script_id: int):
+    async def broken_get_user_images(user_id: int):
         raise HTTPException(status_code=404, detail="not found")
 
-    monkeypatch.setattr(upload_service, "get_script_images", broken_get_script_images)
+    monkeypatch.setattr(upload_service, "get_user_images", broken_get_user_images)
 
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get("/api/images/42/")
+        resp = await ac.get("/api/images/123/")
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "not found"

--- a/app/tests/test_fetch_images_endpoints.py
+++ b/app/tests/test_fetch_images_endpoints.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import AsyncClient, ASGITransport
+
+from app.services.image_uploads.uploads import upload_service
+
+
+@pytest.mark.asyncio
+async def test_get_script_images_success(monkeypatch, app: FastAPI):
+    transport = ASGITransport(app=app)
+
+    fake_images = [
+        {"file_path": "https://example.com/a.jpg", "script_id": 42, "chapter": 1, "ayat_start": 1, "ayat_end": 2},
+        {"file_path": "https://example.com/b.jpg", "script_id": 42, "chapter": 2, "ayat_start": 3, "ayat_end": 4},
+    ]
+
+    async def fake_get_script_images(script_id: int):
+        return fake_images
+
+    monkeypatch.setattr(upload_service, "get_script_images", fake_get_script_images)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/images/42/")
+
+    assert resp.status_code == 200
+    assert resp.json() == fake_images
+
+
+@pytest.mark.asyncio
+async def test_get_script_images_failure(monkeypatch, app: FastAPI):
+    transport = ASGITransport(app=app)
+
+    async def broken_get_script_images(script_id: int):
+        raise HTTPException(status_code=404, detail="not found")
+
+    monkeypatch.setattr(upload_service, "get_script_images", broken_get_script_images)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/images/42/")
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "not found"

--- a/app/tests/test_upload_endpoints.py
+++ b/app/tests/test_upload_endpoints.py
@@ -12,13 +12,13 @@ async def test_upload_success(monkeypatch, app: FastAPI):
     transport = ASGITransport(app=app)
     # 1) arrange: fake upload_service.upload_image to return a known response
     fake_resp = {"file_path": "https://example.com/foo.jpg", "message": "Uploaded successfully"}
-    async def fake_upload_image(file, user_id, chapter, ayat_start, ayat_end):
+    async def fake_upload_image(file, user_id, script_id, chapter, ayat_start, ayat_end):
         return fake_resp
     monkeypatch.setattr(upload_service, "upload_image", fake_upload_image)
 
     # 2) prepare form-data: a small in-memory file + metadata JSON
     file_bytes = b"JPEGDATA"
-    metadata = {"user_id": 42, "chapter": 1, "ayat_start": 2, "ayat_end": 3}
+    metadata = {"user_id": 42, "script_id": 7, "chapter": 1, "ayat_start": 2, "ayat_end": 3}
 
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
@@ -53,7 +53,7 @@ async def test_upload_service_failure(monkeypatch, app: FastAPI):
         raise HTTPException(status_code=502, detail="upstream failed")
     monkeypatch.setattr(upload_service, "upload_image", broken_upload)
 
-    metadata = {"user_id": 1, "chapter": 1, "ayat_start": 1, "ayat_end": 1}
+    metadata = {"user_id": 1, "script_id": 7, "chapter": 1, "ayat_start": 1, "ayat_end": 1}
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/api/upload/",


### PR DESCRIPTION
## Summary
- include `script_id` on image records and request schemas
- implement `ImageUploadCrud` and use it to fetch images for a script
- expose `/images/{script_id}/` API backed by the new CRUD logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa55bddab88326b4a5b184de4758db