### PR TITLE
feat: list user image uploads endpoint

### DIFF
--- a/app/api/v1/routes.py
+++ b/app/api/v1/routes.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter, File, UploadFile, Form, HTTPException, Query, Depends, Request
 
 from app.db.pg_engine import get_db_session
-from app.services.image_uploads.schemas import ImageUploadResponse, ImageUploadInputRequest
+from app.services.image_uploads.schemas import (
+    ImageUploadResponse,
+    ImageUploadInputRequest,
+    ImageUploadRecord,
+)
 from app.services.image_uploads.uploads import upload_service
 from app.services.auth.email_password.email_registration import email_registration
 from app.services.auth.email_password.login_user_pass import LoginUserPass
@@ -36,6 +40,11 @@ async def upload_image(file: UploadFile = File(...), metadata: str = Form(...)):
         script_id=meta_obj.script_id
     )
     return upload_resp
+
+
+@router.get("/uploads/{user_id}", response_model=list[ImageUploadRecord])
+async def get_user_uploads(user_id: int):
+    return await upload_service.get_user_uploads(user_id)
 
 @router.post("/register", response_model=EmailRegistrationResponse, status_code=201)
 async def register(user_in: EmailRegistrationInput):

--- a/app/db/crud/image_uploads.py
+++ b/app/db/crud/image_uploads.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.configs.constants import ProcessingStatus
 from app.db.models.image_uploads import ImageUploads
-from app.db.pg_dml import insert_record
+from app.db.pg_dml import insert_record, get_many
 
 
 class ImageUploadCRUD:
@@ -34,3 +34,11 @@ class ImageUploadCRUD:
             upload_timestamp=upload_timestamp or datetime.now(timezone.utc),
         )
         return await insert_record(db, row)
+
+    async def get_by_user(
+        self,
+        db: AsyncSession,
+        user_id: int,
+    ) -> list[ImageUploads]:
+        """Fetch all uploads for a given user."""
+        return await get_many(db, ImageUploads, filters={"user_id": user_id})

--- a/app/services/image_uploads/schemas.py
+++ b/app/services/image_uploads/schemas.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
+from app.configs.constants import ProcessingStatus
 
 class ImageUploadInputRequest(BaseModel):
     user_id: int
@@ -11,3 +12,17 @@ class ImageUploadInputRequest(BaseModel):
 class ImageUploadResponse(BaseModel):
     file_path: str
     message: str
+
+
+class ImageUploadRecord(BaseModel):
+    file_path: str
+    status: ProcessingStatus
+    chapter: int
+    ayat_start: int
+    ayat_end: int
+
+    @field_serializer("status")
+    def serialize_status(
+        self, status: ProcessingStatus, _info
+    ) -> str:
+        return status.name.lower()

--- a/app/services/image_uploads/uploads.py
+++ b/app/services/image_uploads/uploads.py
@@ -48,9 +48,18 @@ class UploadService:
                 raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}")
 
     async def get_user_uploads(self, user_id: int) -> list[ImageUploadRecord]:
-        """Return all uploads for a specific user."""
+        """Return all uploads for a specific user.
+
+        The mobile client expects a successful request to return JSON even when
+        no uploads exist.  Instead of raising ``HTTPException`` on an empty
+        result set, simply return an empty list so the response body is ``[]``.
+        """
         async with sessionmanager.session() as session:
             rows = await self.crud.get_by_user(session, user_id)
+
+        if not rows:
+            return []
+
         return [
             ImageUploadRecord(
                 file_path=row.file_path,

--- a/app/tests/test_upload_endpoints.py
+++ b/app/tests/test_upload_endpoints.py
@@ -114,6 +114,8 @@ async def test_get_user_uploads_empty(monkeypatch, app: FastAPI):
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/uploads/42")
 
+    data = resp.json()
     assert resp.status_code == 200
-    assert resp.json() == []
+    assert data == []
+    assert isinstance(data, list)
 

--- a/app/tests/test_upload_endpoints.py
+++ b/app/tests/test_upload_endpoints.py
@@ -101,3 +101,19 @@ async def test_get_user_uploads(monkeypatch, app: FastAPI):
     assert resp.status_code == 200
     assert resp.json() == fake_resp
 
+
+@pytest.mark.asyncio
+async def test_get_user_uploads_empty(monkeypatch, app: FastAPI):
+    transport = ASGITransport(app=app)
+
+    async def fake_get_user_uploads(user_id):
+        return []
+
+    monkeypatch.setattr(upload_service, "get_user_uploads", fake_get_user_uploads)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/uploads/42")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+

--- a/app/tests/test_upload_service.py
+++ b/app/tests/test_upload_service.py
@@ -1,0 +1,64 @@
+import pytest
+from app.services.image_uploads.uploads import UploadService
+from app.configs.constants import ProcessingStatus
+import app.services.image_uploads.uploads as uploads_module
+
+
+class DummyRow:
+    def __init__(self, file_path: str, status: ProcessingStatus, chapter: int, ayat_start: int, ayat_end: int):
+        self.file_path = file_path
+        self.status = status
+        self.chapter = chapter
+        self.ayat_start = ayat_start
+        self.ayat_end = ayat_end
+
+
+class DummySessionContext:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummySessionManager:
+    def session(self):
+        return DummySessionContext()
+
+
+@pytest.mark.asyncio
+async def test_get_user_uploads_serializes_status(monkeypatch):
+    service = UploadService()
+
+    async def fake_get_by_user(session, user_id):
+        return [
+            DummyRow("https://a.jpg", ProcessingStatus.UPLOADED, 1, 1, 2),
+            DummyRow("https://b.jpg", ProcessingStatus.PROCESSING, 2, 3, 4),
+        ]
+
+    monkeypatch.setattr(service.crud, "get_by_user", fake_get_by_user)
+    monkeypatch.setattr(uploads_module, "sessionmanager", DummySessionManager())
+
+    records = await service.get_user_uploads(5)
+    assert records[0].model_dump() == {
+        "file_path": "https://a.jpg",
+        "status": "uploaded",
+        "chapter": 1,
+        "ayat_start": 1,
+        "ayat_end": 2,
+    }
+    assert records[1].model_dump()["status"] == "processing"
+
+
+@pytest.mark.asyncio
+async def test_get_user_uploads_empty(monkeypatch):
+    service = UploadService()
+
+    async def fake_get_by_user(session, user_id):
+        return []
+
+    monkeypatch.setattr(service.crud, "get_by_user", fake_get_by_user)
+    monkeypatch.setattr(uploads_module, "sessionmanager", DummySessionManager())
+
+    records = await service.get_user_uploads(5)
+    assert records == []

--- a/app/tests/test_upload_service.py
+++ b/app/tests/test_upload_service.py
@@ -62,3 +62,4 @@ async def test_get_user_uploads_empty(monkeypatch):
 
     records = await service.get_user_uploads(5)
     assert records == []
+    assert isinstance(records, list)


### PR DESCRIPTION
## Summary
- add CRUD and service support for fetching user upload records
- expose `GET /uploads/{user_id}` returning image paths, processing status, and metadata
- cover new endpoint with tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies azure-ai-vision-imageanalysis==1.0.0)*
- `pip install fastapi httpx pytest pytest-asyncio` *(fails: Could not find a version that satisfies fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ab9b14a6848326a4dffdc209d8e5ee