### PR TITLE
Add logging for exception paths

### DIFF
--- a/app/api/v1/routes.py
+++ b/app/api/v1/routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, File, UploadFile, Form, HTTPException, Query, Depends, Request
+import logging
 
 from app.db.pg_engine import get_db_session
 from app.services.image_uploads.schemas import (
@@ -29,8 +30,9 @@ router = APIRouter()
 async def upload_image(file: UploadFile = File(...), metadata: str = Form(...)):
     try:
         meta_obj = ImageUploadInputRequest.model_validate_json(metadata)
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Invalid upload metadata")
+    except Exception:
+        logging.exception("Invalid upload metadata")
+        raise HTTPException(status_code=400, detail="Invalid upload metadata")
     upload_resp = await upload_service.upload_image(
         file,
         user_id=meta_obj.user_id,

--- a/app/db/pg_dml.py
+++ b/app/db/pg_dml.py
@@ -2,6 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import TypeVar, Any, Optional, Type, Sequence
 from sqlalchemy import exc, select
 from sqlalchemy.orm import InstrumentedAttribute
+import logging
 
 T = TypeVar("T", bound=object)
 
@@ -16,7 +17,8 @@ async def insert_record(
         return model_instance
     except exc.SQLAlchemyError as e:
         await session.rollback()
-        raise e
+        logging.exception("Failed to insert record")
+        raise
 
 async def upsert_record(session: AsyncSession, instance: T) -> T:
     try:
@@ -25,6 +27,7 @@ async def upsert_record(session: AsyncSession, instance: T) -> T:
         return merged
     except Exception:
         await session.rollback()
+        logging.exception("Failed to upsert record")
         raise
 
 

--- a/app/db/pg_engine.py
+++ b/app/db/pg_engine.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+import logging
 
 class PgEngine:
     def __init__(self):
@@ -34,6 +35,7 @@ class PgEngine:
                 yield connection
             except Exception:
                 await connection.rollback()
+                logging.exception("Database connection context failed")
                 raise
 
     @asynccontextmanager
@@ -44,6 +46,7 @@ class PgEngine:
                 await session.commit()
             except Exception:
                 await session.rollback()
+                logging.exception("Database session context failed")
                 raise
             finally:
                 await session.close()

--- a/app/services/auth/email_password/email_registration.py
+++ b/app/services/auth/email_password/email_registration.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException
 from fastapi_mail import FastMail, MessageSchema, MessageType
 from sqlalchemy.exc import SQLAlchemyError
+import logging
 
 from app.db.pg_engine import sessionmanager
 from app.db.pg_dml import insert_record, upsert_record
@@ -28,6 +29,7 @@ class EmailRegistration:
                 )
                 return await insert_record(s, user)
             except SQLAlchemyError as e:
+                logging.exception("Failed to insert user record")
                 raise HTTPException(
                     status_code=400,
                     detail=f"Failed to insert record: {str(e)}"
@@ -92,6 +94,7 @@ class EmailRegistration:
                 return "Email verified successfully."
             except SQLAlchemyError:
                 await s.rollback()
+                logging.exception("Database error while verifying email")
                 raise HTTPException(status_code=500,
                                     detail="Database error while verifying email")
 

--- a/app/services/image_uploads/uploads.py
+++ b/app/services/image_uploads/uploads.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from fastapi import UploadFile, HTTPException
+import logging
 
 from app.db.pg_engine import sessionmanager
 from app.db.crud.image_uploads import ImageUploadCRUD
@@ -45,6 +46,7 @@ class UploadService:
                     message="Uploaded successfully",
                 )
             except Exception as e:
+                logging.exception("Failed to upload image")
                 raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}")
 
     async def get_user_uploads(self, user_id: int) -> list[ImageUploadRecord]:

--- a/app/services/storage/do_space.py
+++ b/app/services/storage/do_space.py
@@ -45,8 +45,8 @@ class DOSpace:
             return self._get_public_url(key)
 
         except Exception as e:
-            logging.error(f"Failed to upload file to DO Spaces: {e}")
-            raise Exception(f"Failed to upload file: {e}")
+            logging.exception("Failed to upload file to DO Spaces")
+            raise Exception("Failed to upload file") from e
 
         finally:
             if os.path.exists(temp_file):
@@ -85,7 +85,8 @@ class DOSpace:
         except ClientError as e:
             if e.response['Error']['Code'] == 'NoSuchKey':
                 return None
-            raise Exception(f"Failed to get file: {str(e)}")
+            logging.exception("Failed to get file")
+            raise Exception("Failed to get file") from e
 
     def delete_file(self, key: str) -> bool:
         """
@@ -107,7 +108,8 @@ class DOSpace:
             )
             return True
         except Exception as e:
-            raise Exception(f"Failed to delete file: {str(e)}")
+            logging.exception("Failed to delete file")
+            raise Exception("Failed to delete file") from e
 
     def get_file_url(self, key: str) -> Optional[str]:
         """


### PR DESCRIPTION
## Summary
- log stack traces before raising errors in DigitalOcean storage interactions
- add logging to database helpers, API routes, and auth service
- ensure failing operations use `logging.exception`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement azure-ai-vision-imageanalysis==1.0.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b20684548883268bd6d6cd3fd58fc3