### PR TITLE
Derive user ID from token for uploads

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,17 @@
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose import JWTError, jwt
+
+from app.core.jwt_helper import jwt_helper
+
+bearer_scheme = HTTPBearer()
+
+async def auth_dependency(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> int:
+    """Validate access token and return the authenticated user's ID."""
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, jwt_helper.access_secret_key, algorithms=[jwt_helper.algorithm])
+        user_id = int(payload.get("sub"))
+    except (JWTError, TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return user_id

--- a/app/services/auth/email_password/schemas.py
+++ b/app/services/auth/email_password/schemas.py
@@ -28,7 +28,6 @@ class LoginEmailResponse(BaseModel):
 
 
 class LogoutInput(BaseModel):
-    user_id: int
     refresh_token: str
 
 

--- a/app/services/image_uploads/schemas.py
+++ b/app/services/image_uploads/schemas.py
@@ -2,7 +2,6 @@ from pydantic import BaseModel, field_serializer
 from app.configs.constants import ProcessingStatus
 
 class ImageUploadInputRequest(BaseModel):
-    user_id: int
     chapter: int
     line_start: int
     line_end: int

--- a/app/services/image_uploads/uploads.py
+++ b/app/services/image_uploads/uploads.py
@@ -3,8 +3,6 @@ from fastapi import UploadFile, HTTPException
 from app.core.logger import logger
 
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.db.pg_engine import sessionmanager
 from app.db.crud.image_uploads import ImageUploadCRUD
 from app.services.image_uploads.schemas import ImageUploadResponse, ImageUploadRecord
 from app.services.storage.do_space import do_space
@@ -51,15 +49,14 @@ class UploadService:
             logger.exception("Failed to upload image")
             raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}")
 
-    async def get_user_uploads(self, user_id: int) -> list[ImageUploadRecord]:
+    async def get_user_uploads(self, db: AsyncSession, user_id: int) -> list[ImageUploadRecord]:
         """Return all uploads for a specific user.
 
         The mobile client expects a successful request to return JSON even when
         no uploads exist.  Instead of raising ``HTTPException`` on an empty
         result set, simply return an empty list so the response body is ``[]``.
         """
-        async with sessionmanager.session() as session:
-            rows = await self.crud.get_by_user(session, user_id)
+        rows = await self.crud.get_by_user(db, user_id)
 
         if not rows:
             return []

--- a/app/tests/test_auth_endpoints.py
+++ b/app/tests/test_auth_endpoints.py
@@ -6,6 +6,7 @@ from app.services.auth.email_password.login_user_pass import LoginUserPass
 from app.services.auth.email_password.logout import Logout
 from app.services.auth.email_password.schemas import LoginEmailResponse, LogoutResponse
 from app.db.pg_engine import get_db_session
+from app.core.jwt_helper import jwt_helper
 
 
 @pytest.mark.asyncio
@@ -74,10 +75,13 @@ async def test_logout_success(monkeypatch, app: FastAPI):
 
     monkeypatch.setattr(Logout, "logout", fake_logout)
     transport = ASGITransport(app=app)
+    token = jwt_helper.create_access_token(sub=1)
+    headers = {"Authorization": f"Bearer {token}"}
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/api/logout",
-            json={"user_id": 1, "refresh_token": "token"},
+            json={"refresh_token": "token"},
+            headers=headers,
         )
 
     assert response.status_code == 200
@@ -96,10 +100,13 @@ async def test_logout_invalid_session(monkeypatch, app: FastAPI):
 
     monkeypatch.setattr(Logout, "logout", fake_logout)
     transport = ASGITransport(app=app)
+    token = jwt_helper.create_access_token(sub=1)
+    headers = {"Authorization": f"Bearer {token}"}
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/api/logout",
-            json={"user_id": 1, "refresh_token": "bad"},
+            json={"refresh_token": "bad"},
+            headers=headers,
         )
 
     assert response.status_code == 401

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,15 +13,17 @@ Use these pages to explore endpoints, schemas, and try requests directly from th
 
 - **Endpoint:** `POST /api/upload/`
 - **Description:** Upload a new image for a user.
+- **Headers:** `Authorization: Bearer <access_token>`
 - **Request:** `multipart/form-data` with fields:
   - `file`: image file to upload.
-  - `metadata`: JSON string with keys `user_id`, `chapter`, `line_start`, `line_end`, and `script_id`.
+  - `metadata`: JSON string with keys `chapter`, `line_start`, `line_end`, and `script_id`.
 - **Response:** `ImageUploadResponse` describing the stored image.
 
 ## List User Uploads
 
-- **Endpoint:** `GET /api/uploads/{user_id}`
-- **Description:** Retrieve image uploads for the specified user.
+- **Endpoint:** `GET /api/uploads/`
+- **Description:** Retrieve image uploads for the authenticated user.
+- **Headers:** `Authorization: Bearer <access_token>`
 - **Response:** List of `ImageUploadRecord` objects.
 
 ## Register User
@@ -45,7 +47,9 @@ Use these pages to explore endpoints, schemas, and try requests directly from th
 ## Logout
 
 - **Endpoint:** `POST /api/logout`
-- **Description:** Invalidate a user's refresh token and end their session.
+- **Description:** Invalidate the authenticated user's refresh token and end their session. The user ID is taken from the Bearer token.
+- **Headers:** `Authorization: Bearer <access_token>`
+- **Request:** JSON object with `refresh_token`.
 - **Response:** `LogoutResponse` confirming logout.
 
 ## Root


### PR DESCRIPTION
## Summary
- drop `user_id` field from upload metadata and rely on JWT subject
- simplify uploads listing to use authenticated user instead of path parameter
- update tests and API docs for token-derived user IDs

## Testing
- `pip install -r requirements.txt` (failed: Could not find a version that satisfies the requirement azure-ai-vision-imageanalysis==1.0.0)
- `pytest` (failed: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68b319528fcc8326af449d819daa37d6