### PR TITLE
Validate session before allowing uploads

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,17 +1,31 @@
 from fastapi import Depends, HTTPException
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
+import uuid
 
 from app.core.jwt_helper import jwt_helper
+from app.db.pg_engine import get_db_session
+from app.db.crud.auth_sessions import AuthSessionCRUD
 
 bearer_scheme = HTTPBearer()
 
-async def auth_dependency(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> int:
+
+async def auth_dependency(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db=Depends(get_db_session),
+) -> int:
     """Validate access token and return the authenticated user's ID."""
     token = credentials.credentials
     try:
-        payload = jwt.decode(token, jwt_helper.access_secret_key, algorithms=[jwt_helper.algorithm])
+        payload = jwt.decode(
+            token, jwt_helper.access_secret_key, algorithms=[jwt_helper.algorithm]
+        )
         user_id = int(payload.get("sub"))
+        session_id = uuid.UUID(payload.get("session_id"))
     except (JWTError, TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    session = await AuthSessionCRUD().get_active_by_id(db, session_id=session_id)
+    if session is None:
         raise HTTPException(status_code=401, detail="Invalid token")
     return user_id

--- a/app/db/crud/auth_sessions.py
+++ b/app/db/crud/auth_sessions.py
@@ -73,6 +73,20 @@ class AuthSessionCRUD:
                 return r
         return None
 
+    async def get_active_by_id(
+        self,
+        db: AsyncSession,
+        *,
+        session_id: uuid.UUID,
+    ) -> Optional[AuthSessions]:
+        row = await get_by_id(db, AuthSessions, session_id)
+        if not row:
+            return None
+        now = datetime.now(timezone.utc)
+        if row.is_revoked or row.expires_at <= now:
+            return None
+        return row
+
     async def revoke(
         self,
         db: AsyncSession,

--- a/app/tests/test_auth_dependency.py
+++ b/app/tests/test_auth_dependency.py
@@ -1,0 +1,47 @@
+import uuid
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.api.auth import auth_dependency
+from app.core.jwt_helper import jwt_helper
+from app.db.crud.auth_sessions import AuthSessionCRUD
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_invalid_session(monkeypatch):
+    token = jwt_helper.create_access_token(
+        sub=1, extra_claims={"session_id": str(uuid.uuid4())}
+    )
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    async def fake_get_active_by_id(self, db, session_id):
+        return None
+
+    monkeypatch.setattr(AuthSessionCRUD, "get_active_by_id", fake_get_active_by_id)
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_dependency(credentials, db=None)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_valid_session(monkeypatch):
+    session_uuid = uuid.uuid4()
+    token = jwt_helper.create_access_token(
+        sub=1, extra_claims={"session_id": str(session_uuid)}
+    )
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    class Dummy:
+        id = session_uuid
+
+    async def fake_get_active_by_id(self, db, session_id):
+        assert session_id == session_uuid
+        return Dummy()
+
+    monkeypatch.setattr(AuthSessionCRUD, "get_active_by_id", fake_get_active_by_id)
+
+    user_id = await auth_dependency(credentials, db=None)
+    assert user_id == 1
+

--- a/app/tests/test_auth_endpoints.py
+++ b/app/tests/test_auth_endpoints.py
@@ -1,12 +1,13 @@
 import pytest
 from fastapi import FastAPI, HTTPException
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 
 from app.services.auth.email_password.login_user_pass import LoginUserPass
 from app.services.auth.email_password.logout import Logout
 from app.services.auth.email_password.schemas import LoginEmailResponse, LogoutResponse
 from app.db.pg_engine import get_db_session
 from app.core.jwt_helper import jwt_helper
+from app.api.auth import auth_dependency
 
 
 @pytest.mark.asyncio
@@ -69,6 +70,7 @@ async def test_logout_success(monkeypatch, app: FastAPI):
     async def override_get_db_session():
         yield None
     app.dependency_overrides[get_db_session] = override_get_db_session
+    app.dependency_overrides[auth_dependency] = lambda: 1
 
     async def fake_logout(self):
         return LogoutResponse(message="Logout successful")
@@ -94,6 +96,7 @@ async def test_logout_invalid_session(monkeypatch, app: FastAPI):
     async def override_get_db_session():
         yield None
     app.dependency_overrides[get_db_session] = override_get_db_session
+    app.dependency_overrides[auth_dependency] = lambda: 1
 
     async def fake_logout(self):
         raise HTTPException(status_code=401, detail="Invalid session")


### PR DESCRIPTION
## Summary
- include session IDs in access tokens at login
- ensure auth dependency rejects requests with revoked/expired sessions
- add tests around session-aware authentication

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement azure-ai-vision-imageanalysis==1.0.0)*
- `pip install fastapi httpx pytest-asyncio` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b6158a18248326bbea19f5c42751e9